### PR TITLE
timer: adaptatif selon navbar

### DIFF
--- a/assets/scss/pages/_home.scss
+++ b/assets/scss/pages/_home.scss
@@ -4,58 +4,67 @@
 // 	background-color: rgba(230, 143, 30, 0.151);
 // }
 
+.timer{
+	/* le décalage vertical (top) augmentera */
+	--timer-top: 0;
+
+	position: absolute;
+	top: var(--timer-top);
+	right: 0;
+	z-index: 2;
+	padding: .5rem;
+
+	/* fond uni (peu importe l'image de fond du `.banner`) */
+	background-color: $secondary-color;
+	color: $light;
+
+	@media (min-width: 767px) {
+		--timer-top: var(--navbar-height, 0);
+	}
+
+	.syotimer-cell {
+				// margin-right: 25px;
+				// margin-bottom: 33px;
+				display:inline-block;
+				@include mobile {
+					margin-right: .5rem;
+					margin-bottom: 1rem;
+				}
+				.syotimer-cell__value {
+					min-width: 5rem;
+					margin-block-end: .25rem;
+					font-family: $secondary-font;
+					font-size: 1.5rem;
+					text-align: center;
+					position: relative;
+					font-weight: bold;
+					line-height: 1;
+					color: inherit;
+				}
+				.syotimer-cell__unit {
+					text-align: center;
+					font-size: 0.8125rem;
+					text-transform: lowercase;
+					font-weight:normal;
+					line-height: 1;
+					letter-spacing: .035em;
+					color: inherit;
+					font-family: $secondary-font;
+				}
+			}
+}
+
 // Banner Styles
 .banner{
-	padding: 250px 0 150px;
+	padding: 16rem 0 10rem;
+	/* Position `relative`, notamment pour positionner le timer dans le coin supérieur droit */
 	position: relative;
-	@include desktop {
-		padding: 100px 0;
+	@media (min-width: 992px) {
+		padding: 12rem 0 8rem;
 	}
 	.block{
 		position: relative;
 		z-index: 10;
-		.timer{
-			.syotimer-cell {
-		        margin-right: 25px;
-		        margin-bottom: 33px;
-		        display:inline-block;
-		        @include mobile {
-		        	margin-right: 10px;
-		        	margin-bottom: 20px;
-		        }
-		        .syotimer-cell__value {
-		        	min-width: 80px;
-		        	font-family: $secondary-font;
-					font-size: 35px;
-					line-height: 77px;
-					text-align: center;
-					position: relative;
-					font-weight: bold;
-					color: $light;
-					border: 2px solid $light;
-					margin-bottom: 8px;
-					border-radius: 100%;
-			        box-shadow: 3.5px 6.062px 0px 0px rgba(0, 0, 0, 0.1);
-			        @include mobile {
-			        	font-size: 30px;
-					}
-					@include mobile-xs{
-						min-width: 65px;
-						line-height: 61px;
-						font-size: 25px;
-					}
-		        }
-		        .syotimer-cell__unit {
-		        	text-align: center;
-					font-size: 1rem;
-					text-transform: lowercase;
-					font-weight:normal;
-					letter-spacing: .035em;
-					color: $light;
-					font-family: $secondary-font;
-		        }
-		      }
-		}
 		h1{
 			font-size: 4.5rem;
 			color: $primary-color;
@@ -91,7 +100,7 @@
 }
 
 .banner-two{
-	padding: 250px 0 150px;
+	padding: 16rem 0 10rem;
 	position: relative;
 	overflow: hidden;
 	.block{

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,17 +6,63 @@
 {{ if .Params.banner.enable}}
 {{ with .Params.banner}}
 <section class="banner bg-banner-one overlay">
+
+  <!-- Coundown Timer -->
+  {{ if .timer.enable }}
+  {{ with .timer }}
+  <div class="timer" data-year="{{.year}}" data-month="{{.month}}" data-day="{{.day}}"></div>
+
+  <script>
+    /**
+     * Barre de navigation qui est `fixed` (collée en haut de l'écran,
+     * peu importe le défilement). On s'en servira pour établir la
+     * hauteur libre nécessaire.
+     * @type {HTMLElement}
+     */
+    const navbarElem = document.querySelector('.navbar.fixed-top');
+    /**
+     * @type {HTMLElement}
+     */
+    const timerElem = document.querySelector('.timer');
+    /**
+     * @type {Number}
+     */
+    let navbarHeight = 0;
+
+    // établir la hauteur
+    calcHauteur();
+
+    // recalculer lorsque la fenêtre est redimensionnée
+    window.addEventListener('resize', () => {
+      calcHauteur();
+    });
+
+    ///////////////
+
+    /**
+     * Établir la hauteur de la barre de navigation
+     */
+    function calcHauteur() {
+      // arrêter si on n'a pas une barre de navigation valide
+      if (!navbarElem) {
+        console.warn('Pas d\'élément navbarElem.')
+        return;
+      }
+      navbarHeight = navbarElem.clientHeight;
+      console.log(`navbarHeight: ${navbarHeight}`)
+      timerElem.setAttribute('style', `--navbar-height: ${navbarHeight}px`);
+
+    }
+
+  </script>
+  {{ end }}
+  {{ end }}
+
   <div class="container">
     <div class="row">
       <div class="col-lg-12">
         <!-- Content Block -->
         <div class="block">
-          <!-- Coundown Timer -->
-          {{ if .timer.enable }}
-          {{ with .timer }}
-          <div class="timer" data-year="{{.year}}" data-month="{{.month}}" data-day="{{.day}}"></div>
-          {{ end }}
-          {{ end }}
 <!--           <div class="calque">-->
           {{with .heading}}<h1>{{ . | markdownify }}</h1>{{end}}
           {{with .heading_2}}<h2>{{ . | markdownify }}</h2>{{end}}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -71,3 +71,5 @@
   </div>
 </nav>
 {{ "<!-- /navigation -->" | safeHTML }}
+
+


### PR DESCRIPTION
voir #10 

---

Cette PR propose une amélioration pour le module décompte sur la page d'accueil, en le repositionnant flottant en haut à droite, mais en fonction de la barre de navigation `fixed` (la barre est fixée, mais pas sur les écrans plus petits). L'implémentation recourt à un tout petit peu de JS (pour aller chercher la hauteur de la navbar) et faire passer l'information via une variable CSS ("custom property").